### PR TITLE
Update AdobeExtensionInstaller.ps1 - Fixed uninstall

### DIFF
--- a/Intune Tools/AdobeExtensionInstaller.ps1
+++ b/Intune Tools/AdobeExtensionInstaller.ps1
@@ -35,7 +35,8 @@ if(Test-Path $UPIA){
     #Uninstall
     if($Uninstall){
         try{
-            $Process = Start-Process -Wait -FilePath $UPIA -ArgumentList "/remove $ExtensionName" -PassThru -NoNewWindow
+            $PluginName = '"' + $ExtensionName + '"'
+            $Process = Start-Process -Wait -FilePath $UPIA -ArgumentList "/remove $PluginName" -PassThru -NoNewWindow
             return $Process.ExitCode
         }
         catch{


### PR DESCRIPTION
Ensured that the quotation marks were included with the $ExtensionName string so it would passthru in the -ArgumentList properly.